### PR TITLE
[BUGFIX] Fix implicit null parameter in controller

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -44,12 +44,11 @@ class BackendController extends ActionController
 
     /**
      * @param ServerRequestInterface $request
-     * @param ResponseInterface|null $response
      * @return ResponseInterface
      *
      * @noinspection PhpUnused
      */
-    public function userLookupAction(ServerRequestInterface $request, ResponseInterface $response = null): ResponseInterface
+    public function userLookupAction(ServerRequestInterface $request): ResponseInterface
     {
         $view = $this->backendViewFactory->create($request, ['josefglatz/beuser-fastswitch']);
 


### PR DESCRIPTION
Implicit nullable parameters are deprecated since PHP 8.4. 

This change fixes the deprecation warning by removing the parameter $response in `\JosefGlatz\BeuserFastswitch\Controller\BackendController::userLookupAction`. It is removed instead of explicitly marked as nullable, because it is not used.