### PR TITLE
Dropdown usability: focus search field on open, open user records in a modal

### DIFF
--- a/Resources/Private/Partials/UserList.html
+++ b/Resources/Private/Partials/UserList.html
@@ -6,7 +6,7 @@
 	<f:then>
 		<f:variable name="editCloseUrl">{be:moduleLink(route: 'dummy')}</f:variable>
 		<f:for each="{users}" as="user">
-			<div class="beuser-fastswitch__useritem dropdown-item">
+			<div class="beuser-fastswitch__useritem dropdown-item" tabindex="-1">
 				<div class="beuser-fastswitch__useritem-icon">
 					<a href="#"
 						 class="t3js-contextmenutrigger"

--- a/Resources/Private/Partials/UserList.html
+++ b/Resources/Private/Partials/UserList.html
@@ -4,6 +4,7 @@
 			data-namespace-typo3-fluid="true">
 <f:if condition="{users}">
 	<f:then>
+		<f:variable name="editCloseUrl">{be:moduleLink(route: 'dummy')}</f:variable>
 		<f:for each="{users}" as="user">
 			<div class="beuser-fastswitch__useritem dropdown-item">
 				<div class="beuser-fastswitch__useritem-icon">
@@ -16,8 +17,7 @@
 					</a>
 				</div>
 				<a class="beuser-fastswitch__useritem-title"
-					 href="{be:uri.editRecord(uid: user.uid, table: 'be_users', returnUrl: returnUrl)}"
-					 target="_new"
+					 href="{be:uri.editRecord(uid: user.uid, table: 'be_users', returnUrl: editCloseUrl)}"
 					 title="{f:translate(key: 'toolbar.beuser.fastswitch.dropdown.user.userNameTitle', extensionName: 'beuser_fastswitch', arguments: {0:user.username})}{f:if(condition: '{user.description}', then: ' ({user.description})')}">
 					<div class="dropdown-table-title-ellipsis">{user.realName}</div>
 					<span class="text-muted dropdown-table-title-ellipsis">{user.username}</span>

--- a/Resources/Public/JavaScript/BeuserFastswitch.js
+++ b/Resources/Public/JavaScript/BeuserFastswitch.js
@@ -2,6 +2,7 @@ import DocumentService from '@typo3/core/document-service.js'
 import RegularEvent from '@typo3/core/event/regular-event.js';
 import DebounceEvent from '@typo3/core/event/debounce-event.js';
 import AjaxRequest from '@typo3/core/ajax/ajax-request.js';
+import Modal from '@typo3/backend/modal.js';
 
 DocumentService.ready().then(function () {
   new RegularEvent('shown.bs.dropdown', function (e) {
@@ -13,6 +14,32 @@ DocumentService.ready().then(function () {
       }
     }
   }).bindTo(document);
+
+  new RegularEvent('click', function (e, target) {
+    e.preventDefault();
+    const modal = Modal.advanced({
+      type: Modal.types.iframe,
+      content: target.href,
+      title: target.title,
+      size: Modal.sizes.full,
+    });
+    modal.addEventListener('typo3-modal-shown', function () {
+      const iframe = modal.querySelector('iframe');
+      iframe.addEventListener('load', function () {
+        let pathname = '';
+        try {
+          pathname = iframe.contentWindow.location.pathname;
+        } catch (err) {
+          return;
+        }
+        // The edit link carries returnUrl={be:moduleLink(route: 'dummy')} (path
+        // /typo3/empty), so close/save&close navigates the iframe there.
+        if (pathname.endsWith('/empty')) {
+          modal.hideModal();
+        }
+      });
+    });
+  }).delegateTo(document, '.tx-beuser-fastswitch a.beuser-fastswitch__useritem-title');
 
   new RegularEvent('submit', function (e) {
     e.preventDefault();

--- a/Resources/Public/JavaScript/BeuserFastswitch.js
+++ b/Resources/Public/JavaScript/BeuserFastswitch.js
@@ -4,6 +4,16 @@ import DebounceEvent from '@typo3/core/event/debounce-event.js';
 import AjaxRequest from '@typo3/core/ajax/ajax-request.js';
 
 DocumentService.ready().then(function () {
+  new RegularEvent('shown.bs.dropdown', function (e) {
+    if (e.target.closest('.tx-beuser-fastswitch') !== null) {
+      const searchMask = document.querySelector('#beuser-fastswitch-search-mask');
+      if (searchMask !== null) {
+        searchMask.focus();
+        searchMask.select();
+      }
+    }
+  }).bindTo(document);
+
   new RegularEvent('submit', function (e) {
     e.preventDefault();
   }).bindTo(document.querySelector('#beuser-fastswitch-search-form'));

--- a/Resources/Public/JavaScript/BeuserFastswitch.js
+++ b/Resources/Public/JavaScript/BeuserFastswitch.js
@@ -15,6 +15,50 @@ DocumentService.ready().then(function () {
     }
   }).bindTo(document);
 
+  // Registered in the capture phase: Bootstrap's delegated dropdown handlers
+  // are capture-phase on document and stop propagation for arrow keys inside
+  // an open menu. Being registered later on the same node, this listener still
+  // runs right after Bootstrap's, so the focus set here wins.
+  new RegularEvent('keydown', function (e) {
+    const toolbarItem = e.target.closest('.tx-beuser-fastswitch');
+    if (toolbarItem === null || !['ArrowDown', 'ArrowUp', 'Enter'].includes(e.key)) {
+      return;
+    }
+    const searchMask = document.querySelector('#beuser-fastswitch-search-mask');
+    const items = Array.from(toolbarItem.querySelectorAll('.beuser-fastswitch__useritem'));
+    const currentItem = e.target.closest('.beuser-fastswitch__useritem');
+
+    if (e.key === 'Enter') {
+      // Switch to the focused user — or to the first match when pressing
+      // Enter in the search field. Inactive users render no switch button.
+      const item = currentItem !== null ? currentItem : (e.target === searchMask ? items[0] : null);
+      const switchUserButton = item ? item.querySelector('typo3-backend-switch-user button') : null;
+      if (switchUserButton !== null) {
+        e.preventDefault();
+        switchUserButton.click();
+      }
+      return;
+    }
+
+    const index = items.indexOf(currentItem);
+    if (e.key === 'ArrowDown' && (currentItem !== null || e.target === searchMask)) {
+      const next = currentItem === null ? items[0] : items[index + 1];
+      if (next !== undefined) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        next.focus();
+      }
+    } else if (e.key === 'ArrowUp' && currentItem !== null) {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      if (index > 0) {
+        items[index - 1].focus();
+      } else if (searchMask !== null) {
+        searchMask.focus();
+      }
+    }
+  }, true).bindTo(document);
+
   new RegularEvent('click', function (e, target) {
     e.preventDefault();
     const modal = Modal.advanced({


### PR DESCRIPTION
This adds two small UX improvements to the toolbar dropdown:

1. Autofocus the search field when the dropdown opens (via shown.bs.dropdown, delegated on document), selecting any previous search term so it can be typed over.
2. Open the be_users edit form in a full-size backend modal (Modal.types.iframe) instead of a new browser window when clicking a user's name. The edit link's returnUrl points to the dummy route (/typo3/empty) — without it, EditDocumentController::resolveDefaultReturnUrl() redirects to the user's first accessible module inside the iframe. A load listener detects that navigation and closes the modal, so Close and Save & Close both dismiss it, and FormEngine's unsaved-changes confirmation keeps working inside the modal.
3. Keyboard navigation by selecting backend user using arrow up and down, and switch to user by pressing enter.

Tested on TYPO3 13.4.31; all APIs used exist in v13.4 and v14.